### PR TITLE
Fix relative imports of two modules

### DIFF
--- a/pytorch_learning_tools/utils/model_utils.py
+++ b/pytorch_learning_tools/utils/model_utils.py
@@ -1,7 +1,7 @@
 import torch
 import importlib
 import torch.optim as optim
-import SimpleLogger
+from ..SimpleLogger import SimpleLogger
 import os
 import torch.nn as nn
 from torch.autograd import Variable
@@ -11,7 +11,7 @@ import pickle
 import importlib
 
 import matplotlib.pyplot as plt
-from imgToProjection import imgtoprojection
+from ..imgToProjection import imgtoprojection
 
 import pdb
 


### PR DESCRIPTION
I'm not sure how you guys are properly importing these other modules, but Python 3.6 wouldn't let me import `pytorch_learning_tools` until I fixed these relative imports. 